### PR TITLE
Adding PyPI deployment GitHub Actions/workflows. Deploys to Test PyPI and production PyPI

### DIFF
--- a/.github/workflows/publish_major_release.yml
+++ b/.github/workflows/publish_major_release.yml
@@ -1,0 +1,51 @@
+name: Publish package
+
+on:
+  push:
+    branches: [main]
+  workflow_run:
+      workflows: [Run Tests]
+      types: [completed]
+
+jobs:
+  on-success:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    strategy:
+      matrix:
+        python-version: [3.11]
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+      - run: echo 'All tests have passed, deploying to Test PyPi!'
+      - run: echo 'Installing build packages...'
+      - name: Install pypa/build
+        run: >-
+          python -m
+          pip install
+          build
+          --user
+      - run: echo 'Building from source...'
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python -m
+          build
+          --sdist
+          --wheel
+          --outdir dist/
+      - run: echo 'Publishing to PyPI, hold on tight!'
+      - name: Publish distribution 📦 to PyPI 
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: echo 'Tests from previous workflow have failed!'

--- a/.github/workflows/publish_major_release.yml
+++ b/.github/workflows/publish_major_release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   workflow_run:
-      workflows: [Run Tests]
+      workflows: [ci-python-unittest]
       types: [completed]
 
 jobs:

--- a/.github/workflows/publish_major_release.yml
+++ b/.github/workflows/publish_major_release.yml
@@ -9,8 +9,8 @@ on:
 
 jobs:
   on-success:
-    runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.11]
@@ -20,16 +20,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-      - run: echo 'All tests have passed, deploying to Test PyPi!'
-      - run: echo 'Installing build packages...'
       - name: Install pypa/build
         run: >-
           python -m
           pip install
           build
           --user
-      - run: echo 'Building from source...'
       - name: Build a binary wheel and a source tarball
         run: >-
           python -m
@@ -37,12 +33,11 @@ jobs:
           --sdist
           --wheel
           --outdir dist/
-      - run: echo 'Publishing to PyPI, hold on tight!'
       - name: Publish distribution 📦 to PyPI 
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          password: ${{ secrets.PYPI_TOKEN }}
 
   on-failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_test_release.yml
+++ b/.github/workflows/publish_test_release.yml
@@ -1,0 +1,51 @@
+name: Publish package
+
+on:
+  push:
+    branches: [dev]
+  workflow_run:
+      workflows: [Run Tests]
+      types: [completed]
+
+jobs:
+  on-success:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    strategy:
+      matrix:
+        python-version: [3.11]
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+      - run: echo 'All tests have passed, deploying to Test PyPi!'
+      - run: echo 'Installing build packages...'
+      - name: Install pypa/build
+        run: >-
+          python -m
+          pip install
+          build
+          --user
+      - run: echo 'Building from source...'
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python -m
+          build
+          --sdist
+          --wheel
+          --outdir dist/
+      - run: echo 'Publishing to Test PyPI, hold on tight!'
+      - name: Publish distribution 📦 to Test PyPI 
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: echo 'Tests from previous workflow have failed!'

--- a/.github/workflows/publish_test_release.yml
+++ b/.github/workflows/publish_test_release.yml
@@ -9,8 +9,8 @@ on:
 
 jobs:
   on-success:
-    runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.11]
@@ -20,16 +20,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-      - run: echo 'All tests have passed, deploying to Test PyPi!'
-      - run: echo 'Installing build packages...'
       - name: Install pypa/build
         run: >-
           python -m
           pip install
           build
           --user
-      - run: echo 'Building from source...'
       - name: Build a binary wheel and a source tarball
         run: >-
           python -m
@@ -37,12 +33,11 @@ jobs:
           --sdist
           --wheel
           --outdir dist/
-      - run: echo 'Publishing to Test PyPI, hold on tight!'
       - name: Publish distribution 📦 to Test PyPI 
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
   on-failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_test_release.yml
+++ b/.github/workflows/publish_test_release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [dev]
   workflow_run:
-      workflows: [Run Tests]
+      workflows: [ci-python-unittest]
       types: [completed]
 
 jobs:

--- a/.github/workflows/run_unittest_on_new_pr.yml
+++ b/.github/workflows/run_unittest_on_new_pr.yml
@@ -7,8 +7,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-workflow_dispatch:
-
 jobs:
   build:
     if: (!(github.event.action == 'closed' && github.event.pull_request.merged != true))

--- a/.github/workflows/run_unittest_on_new_pr.yml
+++ b/.github/workflows/run_unittest_on_new_pr.yml
@@ -5,8 +5,7 @@ name: ci-python-unittest
 
 on:
   pull_request:
-    branches: [dev, main]
-  types: [opened, synchronize, closed]
+    types: [opened, synchronize, reopened]
 
 workflow_dispatch:
 

--- a/.github/workflows/run_unittest_on_new_pr.yml
+++ b/.github/workflows/run_unittest_on_new_pr.yml
@@ -4,13 +4,8 @@
 name: ci-python-unittest
 
 on:
-  push:
-    branches:
-      - "**"
-      - "!main"
-pull_request:
-  branches:
-    - main
+  pull_request:
+    branches: [dev, main]
   types: [opened, synchronize, closed]
 
 workflow_dispatch:

--- a/.github/workflows/run_unittest_on_new_pr.yml
+++ b/.github/workflows/run_unittest_on_new_pr.yml
@@ -4,11 +4,20 @@
 name: ci-python-unittest
 
 on:
-  pull_request:
-    branches: [dev, main]
+  push:
+    branches:
+      - "**"
+      - "!main"
+pull_request:
+  branches:
+    - main
+  types: [opened, synchronize, closed]
+
+workflow_dispatch:
 
 jobs:
   build:
+    if: (!(github.event.action == 'closed' && github.event.pull_request.merged != true))
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Adding PyPI deployment GitHub Actions/workflows. Deploys to Test PyPI for dev changes in the dev branch and PyPI for production major releases pushed to the main branch via pull request. Major releases must have a tag in the commit message to main. Runs tests on a new PR, changes to a PR and closing of a PR.