### PR TITLE
Oscilation bug fix

### DIFF
--- a/pyFoF/fof.py
+++ b/pyFoF/fof.py
@@ -153,7 +153,7 @@ class ClassicFoF(BaseFoF):
         friends_before = np.array([])
 
         iterations = 0
-        while np.array_equal(friends_after, friends_before) is False:
+        while np.array_equal(friends_after, friends_before) is False and iterations < 100:
             iterations += 1
             friends_before = friends_after
             friends_after = np.unique(np.concatenate(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "FoFpy"
-version = "1.0.11"
+version = "1.0.12"
 authors = [
   "Trystan Scott Lambert <trystanscottlambert@gmail.com>",
   "Victor Gueorguiev Gueorguiev <victor.gueorg@gmail.com>"


### PR DESCRIPTION
Their were rare occasion were the group finder would never exit a while group because it would continuously add and remove sets of members. This fixes the issue by including a kill condition. See issue #70 